### PR TITLE
Fix add member at index

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ FocusGroup.prototype.addMember = function(member, index) {
     text: cleanedNodeText,
   };
 
-  if (index) {
+  if (index !== null && index !== undefined) {
     this._members.splice(index, 0, member);
   } else {
     this._members.push(member);

--- a/test/integration.js
+++ b/test/integration.js
@@ -309,10 +309,12 @@ describe('dynamically adding and removing nodes', function() {
 
   it('adds a member at an index with addMember(node, index)', function() {
     this.focusGroup.setMembers([nodeThree, nodeFour]);
+    this.focusGroup.addMember(nodeOne, 0);
     this.focusGroup.addMember(nodeTwo, 1);
     assert.deepEqual(this.focusGroup.getMembers(), [
-      { node: nodeThree, text: 'three' },
+      { node: nodeOne, text: 'one' },
       { node: nodeTwo, text: 'two' },
+      { node: nodeThree, text: 'three' },
       { node: nodeFour, text: "" },
     ]);
   });


### PR DESCRIPTION
This fixes an issue where providing an `index` of `0` to `addMember` would append the element to the list of members.

This is because the conditional which checks for the presence of `index` only checks for falsey values, and  so an `index` of `0` evaluates to `false`.
