### PR TITLE
Fake focusing elements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -113,11 +113,19 @@
     <li><a href="#" class="wra">Friedan, Betty</a></li>
   </ul>
 
+  <ul id="select-root" tabindex="0">
+    <li class="select">Number 1</li>
+    <li class="select">Number 2</li>
+    <li class="select">Number 3</li>
+    <li class="select">Number 4</li>
+  </ul>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/davidtheclark/focus-group" style="vertical-align:middle;">Return to the repository</a>
   </p>
 
+  <script src="https://unpkg.com/mitt/dist/mitt.umd.js"></script>
   <script src="demo-bundle.js"></script>
 </body>
 </html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -18,3 +18,23 @@ createFocusGroup({
 	},
 	wrap: true,
 }).activate();
+
+var selectRoot = document.getElementById('select-root');
+var selectNodes = document.querySelectorAll('.select');
+var focusGroup = createFocusGroup({
+  rootNode: selectRoot,
+	members: selectNodes,
+	stringSearch: true,
+	keybindings: {
+		next: [{ keyCode: 40 }, { keyCode: 39 }],
+		prev: [{ keyCode: 38 }, { keyCode: 37 }]
+	},
+	wrap: true,
+}).activate();
+
+focusGroup.on('focus', function (member) {
+	for (var i = 0; i < selectNodes.length; i++) {
+		var selectNode = selectNodes[i]
+		selectNode.classList.toggle('highlighted', selectNode === member.node)
+	}
+})

--- a/demo/style.css
+++ b/demo/style.css
@@ -14,6 +14,7 @@ body {
 
 input:focus,
 a:focus,
-button:focus {
+button:focus,
+.highlighted {
   outline: 5px solid lightblue;
 }


### PR DESCRIPTION
This PR allows the ability to create a fake focus group for a set of elements. By setting the `rootNode` option to something other than `document` this will allow you to create a focus group that you can control while still giving focus to another element, think select box, combobox, etc.

### Changes
`addMember` method accepts additional options: `id`, `index`, and `value`. I found this optional information to be useful when working with select menus and comboboxes.

Integrates [mitt](https://github.com/developit/mitt) to allow someone to tie into events like `focus` and `select`.

#### Options added:

`rootNode`: this defaults to `document` and is what the `keydown` event listeners get attached to

`initialIndex`: this is the starting index, useful for something like setting the current option before opening a menu and creating a new focus group

`keybindings.select`: the keybindings for selecting and element, defaults to the `Enter` key